### PR TITLE
Windows fixes and fix #6

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,8 @@
 using Conda
 
 # Let's see if Conda is installed. If not, let's do that first!
-if !isexecutable(Conda.conda)
+@unix_only is_installed = isexecutable(Conda.conda)
+@windows_only is_installed =  isfile(Conda.conda * ".exe")
+if !is_installed
     Conda._install_conda()
 end

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -78,7 +78,7 @@ function _install_conda()
         run(`$installer -b -f -p $PREFIX`)
     end
     @windows_only begin
-        run(`$installer /S /D=$PREFIX`)
+        run(`$installer /S  /AddToPath=0 /RegisterPython=0 /D=$PREFIX`)
     end
 end
 

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -30,7 +30,7 @@ using Compat
 using JSON
 
 "Prefix for installation of all the packages."
-const PREFIX = Pkg.dir("Conda", "deps", "usr")
+const PREFIX = abspath(dirname(@__FILE__), "..", "deps", "usr")
 
 @unix_only const conda = joinpath(PREFIX, "bin", "conda")
 @windows_only const conda = joinpath(PREFIX, "Scripts", "conda")


### PR DESCRIPTION
This fixes two issues on windows and #6. The first issues is that the Miniconda installer will add miniconda to path even after  0b395fe. This can be disabled by command line arguments to the installer. This change is made in 6dff8d7 the information about the command line arguments can be found in https://github.com/conda/conda/issues/1068. 

The second issue is that `isexecutable` on https://github.com/Luthaf/Conda.jl/blob/1156d54d7dab917698ab5d7bebc1a027dcb46c47/deps/build.jl#L4 always returns false even though miniconda is installed and conda.exe exist. Therefore I have relaxed the test on windows to if `isfile(Conda.conda * ".exe")` returns false.

@tkelman Is it a bug that `isexecutable("bin\\julia.exe")` returns false?