### PR TITLE
Fix scriptdir/bindir

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -32,37 +32,23 @@ using JSON
 "Prefix for installation of all the packages."
 const PREFIX = abspath(dirname(@__FILE__), "..", "deps", "usr")
 """Returns the directory for the binary files of a package. Attention on unix
- `bindir` and `scriptsdir` returns the same path while on windows it is two separate directories.
- Use `scriptdir()` to ex. get numpy's f2py or ipython"""
-@unix_only begin function bindir(package) 
-        packages = _installed_packages_dict()
-        haskey(packages, package) || error("Package '$package' not found")
-        joinpath(PREFIX, "pkgs", packages[package][2], "bin")
-    end
-end
+ `Conda.BINDIR` and `Conda.SCRIPTDIR` returns the same path while on windows it is two separate directories.
+ Use `Conda.SCRIPTDIR` to ex. get the folder for numpy's f2py or ipython"""
+@unix_only const BINDIR = joinpath(PREFIX, "bin")
 """Returns the directory for the scripts files of a package. Attention on unix
- `bindir` and `scriptsdir` returns the same path while on windows it is two separate directories.
- Use `scriptdir()` to ex. get numpy's f2py or ipython"""
-scriptsdir(package) = bindir(package)
+ `Conda.BINDIR` and `Conda.SCRIPTDIR` returns the same path while on windows it is two separate directories.
+ Use `Conda.SCRIPTDIR` to ex. get the folder for numpy's f2py or ipython"""
+@unix_only const SCRIPTDIR = joinpath(PREFIX, "bin")
 """Returns the directory for the binary files of a package. Attention on unix
- `bindir` and `scriptsdir` returns the same path while on windows it is two separate directories.
- Use `scriptdir()` to ex. get numpy's f2py or ipython"""
-@windows_only function bindir(package) 
-    packages = _installed_packages_dict()
-    haskey(packages, package) || error("Package '$package' not found")
-    joinpath(PREFIX, "pkgs", packages[package][2], "Library", "bin")
-end
+ `Conda.BINDIR` and `Conda.SCRIPTDIR` returns the same path while on windows it is two separate directories.
+ Use `Conda.SCRIPTDIR` to ex. get the folder for numpy's f2py or ipython"""
+@windows_only  const BINDIR = joinpath(PREFIX, "Library", "bin")
 """Returns the directory for the scripts files of a package. Attention on unix
- `bindir` and `scriptsdir` returns the same path while on windows it is two separate directories.
- Use `scriptdir()` to ex. get numpy's f2py or ipython"""
-@windows_only function scriptsdir(package) 
-    packages = _installed_packages_dict()
-    haskey(packages, package) || error("Package '$package' not found")
-    joinpath(PREFIX, "pkgs", packages[package][2], "Scripts")
-end
+ `Conda.BINDIR` and `Conda.SCRIPTDIR` returns the same path while on windows it is two separate directories.
+ Use `Conda.SCRIPTDIR` to ex. get the folder for numpy's f2py or ipython"""
+@windows_only const SCRIPTDIR = joinpath(PREFIX, "Scripts")
 
-@unix_only const conda = joinpath(PREFIX, "bin", "conda")
-@windows_only const conda = joinpath(PREFIX, "Scripts", "conda")
+const conda = joinpath(SCRIPTDIR, "conda")
 
 CHANNELS = AbstractString[]
 additional_channels() = ["--channel " * channel for channel in CHANNELS]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ end
 
 @test isfile(curl_path)
 
-@test isfile(joinpath(Conda.bindir("curl"), basename(curl_path)))
+@test isfile(joinpath(Conda.BINDIR, basename(curl_path)))
 
 Conda.rm("curl")
 @unix_only @test !isfile(curl_path)
@@ -25,4 +25,8 @@ if already_installed
     Conda.add("curl")
 end
 
-@test isfile(joinpath(Conda.scriptsdir("conda"), "conda" * @windows ? ".exe": ""))
+@test isfile(joinpath(Conda.SCRIPTDIR, "conda" * @windows ? ".exe": ""))
+
+Conda.add("jupyter=1.0.0")
+@test v"4.0.0" == convert(VersionNumber, chomp(readall(`$(joinpath(Conda.SCRIPTDIR, "jupyter-kernelspec")) --version`)))
+


### PR DESCRIPTION
When I tried to update https://github.com/JuliaLang/IJulia.jl/pull/357 to use the bindir and scriptdir function I found that the function pointed to the wrong scripts/bins. The scripts within the pkgs cannot be used because they cannot find the python interpreter. On Linux the Ipython script in  `deps/usr/bin` works as intended and it looks like:
```
#!/home/hoegh/anaconda3/bin/python3
if __name__ == '__main__':
    import sys
    from IPython import start_ipython

    sys.exit(start_ipython())
```
the equivalent script in `deps/usr/bin/pkgs/ipython-3.1.0-py34_0/bin` do not work because it cannot find the python interpreter referenced in the first line.
```
#!/opt/anaconda1anaconda2anaconda3/bin/python3
if __name__ == '__main__':
    import sys
    from IPython import start_ipython

    sys.exit(start_ipython())
```
The case is the same on windows where executables inside `deps\usr\pkgs` do not work, while the equivalent executable in `deps\usr\Scripts` work. Therefore this PR update's to use the global `bin` directory on Linux and `Scripts` directory windows in `deps/usr/`. As `bindir/scriptdir` is not package dependent anymore I have made them constants and capitalized.