### PR TITLE
Add PYTHONDIR.

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -46,6 +46,11 @@ SCRIPTDIR
 "Prefix for the executable files installed with the packages"
 BINDIR
 
+"Returns the directory for python"
+@windows_only const PYTHONDIR = PREFIX
+"Returns the directory for python"
+@unix_only const PYTHONDIR = BINDIR
+
 const conda = joinpath(SCRIPTDIR, "conda")
 
 CHANNELS = AbstractString[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,3 +26,6 @@ if already_installed
 end
 
 @test isfile(joinpath(Conda.SCRIPTDIR, "conda" * @windows ? ".exe": ""))
+
+@test isfile(joinpath(Conda.PYTHONDIR, "python" * @windows ? ".exe": ""))
+


### PR DESCRIPTION
Add the path to python as a constant. The need were discovered during https://github.com/stevengj/PyCall.jl/pull/191. When merged could you tag version 1.6, so I can continue my quest of widespread adoption of Conda.