### PR TITLE
lazy installation: run _install_conda() the first time Conda is used

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,8 +1,0 @@
-using Conda
-
-# Let's see if Conda is installed. If not, let's do that first!
-@unix_only is_installed = isexecutable(Conda.conda)
-@windows_only is_installed =  isfile(Conda.conda * ".exe")
-if !is_installed
-    Conda._install_conda()
-end


### PR DESCRIPTION
This installs miniconda only the first time Conda is used (e.g. on the first `Conda.add` or similar), rather than in `Pkg.build`.

This allows packages like PyCall to REQUIRE Conda as an optional dependency provider, but doesn't force users to install miniconda unless it is actually needed.

Fixes stevengj/PyCall.jl#198