### PR TITLE
enable precompilation

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -64,7 +64,7 @@ function _set_conda_env(cmd)
     setenv(cmd, env)
 end
 
-CHANNELS = AbstractString[]
+const CHANNELS = UTF8String[]
 "Get the list of additional channels"
 function additional_channels()
     res = AbstractString[]

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -1,3 +1,5 @@
+VERSION >= v"0.4.0-dev+6521" && __precompile__()
+
 """
 The Conda module provides access to the [conda](http://conda.pydata.org/) packages
 manager. Its main purpose is to be used as a BinDeps provider, to install binary


### PR DESCRIPTION
This enables precompilation on 0.4; as far as I can tell, Conda is precompile-safe.  (Furthermore, Conda will often get precompiled anyway if it is imported by a precompiled package like PyPlot, so this just makes it "official".)

As a separate slight optimization, I made the `CHANNELS` array `const` and gave it a concrete type.  You can still modify it with `push!` etcetera, you just can't assign it to a completely different array. The concrete type is `UTF8String`, so you can still push any other unicode-compatible string type to the array, and it will just get converted upon assignment.