### PR TITLE
fix #25 (new fix for #15 that does not involve powershell)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - osx
     - linux
 julia:
-    - 0.3
     - 0.4
     - 0.5
     - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3.3
+julia 0.4
 BinDeps
-Compat 0.7.20
+Compat 0.8
 JSON

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.3/julia-0.3-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.3/julia-0.3-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
@@ -23,6 +21,6 @@ build_script:
   - IF EXIST .git\shallow (git fetch --unshallow)
   # Test #17 by using ENV[\"HOME\"]=joinpath(homedir(),\"Conda test home\")
   - C:\projects\julia\bin\julia -e "versioninfo(); p = joinpath(homedir(),\"Conda test home\"); mkdir(p); ENV[\"HOME\"]=p; Pkg.clone(pwd(), \"Conda\"); Pkg.build(\"Conda\")"
-  
+
 test_script:
   - C:\projects\julia\bin\julia --check-bounds=yes -e "ENV[\"HOME\"]=joinpath(homedir(),\"Conda test home\"); Pkg.test(\"Conda\")"

--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__()
+__precompile__()
 
 """
 The Conda module provides access to the [conda](http://conda.pydata.org/) packages
@@ -90,15 +90,17 @@ function _installer_url()
     return res
 end
 
+is_windows() && include("outlook.jl")
+
 "Install miniconda if it hasn't been installed yet; _install_conda(true) installs Conda even if it has already been installed."
 function _install_conda(force=false)
     if is_windows()
-          if try success(pipeline(`powershell "Get-Process Outlook"`, stdout=DevNull, stderr=DevNull)); catch; false; end
+          if is_outlook_running()
               error("""\n
-              Outlook is running, running the Miniconda installer will crash it.
-              Please stop Outlook, and restart the installation.
+              Outlook is running, and running the Miniconda installer will crash it.
+              Please quit Outlook and then restart the installation.
 
-              For more informations, see
+              For more information, see:
                     https://github.com/Luthaf/Conda.jl/issues/15
                     https://github.com/conda/conda/issues/1084
               """)

--- a/src/outlook.jl
+++ b/src/outlook.jl
@@ -1,0 +1,35 @@
+# Code to test whether Outlook is running on Windows.   This is used
+# to work around a bug in the Miniconda installer, which crashes Outlook
+# if it is running.  See Luthaf/Conda.jl#15
+
+immutable PROCESSENTRY32
+    dwSize::Int32
+    cntUsage::Int32
+    th32ProcessID::Int32
+    th32DefaultHeapID::UInt
+    th32ModuleID::Int32
+    cntThreads::Int32
+    th32ParentProcessID::Int32
+    pcPriClassBase::Int32
+    dwFlags::UInt32
+    szExeFile::NTuple{260,UInt8}
+    PROCESSENTRY32() = new(sizeof(PROCESSENTRY32),0,0,0,0,0,0,0,0)
+end
+szExeFile(p::PROCESSENTRY32) = unsafe_string(pointer(collect(p.szExeFile)))
+const TH32CS_SNAPPROCESS = 0x00000002
+function isrunning(exefile::AbstractString)
+    snapshot = ccall(:CreateToolhelp32Snapshot, stdcall, Ptr{Void}, (UInt32,Int32), TH32CS_SNAPPROCESS, 0)
+    try
+        entry = Ref(PROCESSENTRY32())
+        if ccall(:Process32First, stdcall, Cint, (Ptr{Void}, Ref{PROCESSENTRY32}), snapshot, entry) == 1
+            szExeFile(entry[]) == exefile && return true
+            while ccall(:Process32Next, stdcall, Cint, (Ptr{Void}, Ref{PROCESSENTRY32}), snapshot, entry) == 1
+                szExeFile(entry[]) == exefile && return true
+            end
+        end
+    finally
+        ccall(:CloseHandle, stdcall, Cint, (Ptr{Void},), snapshot)
+    end
+    return false
+end
+is_outlook_running() = isrunning("outlook.exe")


### PR DESCRIPTION
This fixes the unwanted PowerShell output of #25, by implementing an entirely different fix for #15 that invokes the Win32 API directly rather than forking powershell.

Unfortunately, I had to drop support for Julia 0.3, as the `NTuple` field of `PROCESSENTRY32` does not work in 0.3 (it doesn't inline in the struct), and the alternative of declaring 260 `UInt8` fields explicitly was too horrible to contemplate.

However, at this point in time, with 0.5 just about out the door and 0.3 unbearably ancient, I think dropping 0.3 support seems reasonable.