### PR TITLE
Fix version for custom channels

### DIFF
--- a/src/Conda.jl
+++ b/src/Conda.jl
@@ -196,7 +196,7 @@ function version(name::AbstractString)
     _install_conda()
     packages = JSON.parse(readstring(`$conda list --json`))
     for package in packages
-        if startswith(package, name)
+        if startswith(package, name) || ismatch(Regex("::$name"), package)
             return package
         end
     end


### PR DESCRIPTION
Custom channel packages don't start with the name. They start with channel name. 
Eg: `conda-forge::mpc`